### PR TITLE
exif, tiff: Simplify and add comments.

### DIFF
--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"strings"
 	"unicode"
@@ -57,7 +58,7 @@ type Tag struct {
 	strVal    string
 }
 
-// DecodeTag parses a tiff-encoded IFD tag from r and returns Tag object. The
+// DecodeTag parses a tiff-encoded IFD tag from r and returns a Tag object. The
 // first read from r should be the first byte of the tag. ReadAt offsets should
 // be relative to the beginning of the tiff structure (not relative to the
 // beginning of the tag).
@@ -91,13 +92,11 @@ func DecodeTag(r ReadAtReader, order binary.ByteOrder) (*Tag, error) {
 		}
 	} else {
 		val := make([]byte, valLen)
-		n, err := r.Read(val)
-		if err != nil || n != int(valLen) {
+		if _, err = io.ReadFull(r, val); err != nil {
 			return nil, errors.New("tiff: tag offset read failed: " + err.Error())
 		}
-
-		n, err = r.Read(make([]byte, 4-valLen))
-		if err != nil || n != 4-int(valLen) {
+		// ignore padding.
+		if _, err = io.ReadFull(r, make([]byte, 4-valLen)); err != nil {
 			return nil, errors.New("tiff: tag offset read failed: " + err.Error())
 		}
 
@@ -114,7 +113,7 @@ func (t *Tag) convertVals() {
 
 	switch t.Fmt {
 	case 2: // ascii string
-		t.strVal = string(t.Val[:len(t.Val)-1])
+		t.strVal = string(t.Val[:len(t.Val)-1]) // ignore the last byte (NULL).
 	case 1:
 		var v uint8
 		t.intVals = make([]int64, int(t.Ncomp))

--- a/tiff/tiff.go
+++ b/tiff/tiff.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 )
@@ -39,17 +40,15 @@ func Decode(r io.Reader) (*Tiff, error) {
 
 	// read byte order
 	bo := make([]byte, 2)
-	n, err := buf.Read(bo)
-	if n < len(bo) || err != nil {
+	if _, err = io.ReadFull(buf, bo); err != nil {
 		return nil, errors.New("tiff: could not read tiff byte order")
+	}
+	if string(bo) == "II" {
+		t.Order = binary.LittleEndian
+	} else if string(bo) == "MM" {
+		t.Order = binary.BigEndian
 	} else {
-		if string(bo) == "II" {
-			t.Order = binary.LittleEndian
-		} else if string(bo) == "MM" {
-			t.Order = binary.BigEndian
-		} else {
-			return nil, errors.New("tiff: could not read tiff byte order")
-		}
+		return nil, errors.New("tiff: could not read tiff byte order")
 	}
 
 	// check for special tiff marker
@@ -91,11 +90,13 @@ func Decode(r io.Reader) (*Tiff, error) {
 }
 
 func (tf *Tiff) String() string {
-	s := "Tiff{"
+	var buf bytes.Buffer
+	fmt.Fprint(&buf, "Tiff{")
 	for _, d := range tf.Dirs {
-		s += d.String() + ", "
+		fmt.Fprintf(&buf, "%s, ", d.String())
 	}
-	return s + "}"
+	fmt.Fprintf(&buf, "}")
+	return buf.String()
 }
 
 // Dir reflects the parsed content of a tiff Image File Directory (IFD).


### PR DESCRIPTION
- Add comment about marker value, EXIF (0xE1 = APP1).
- Simplify newAppSec.
- Use io.ReadFull where appropriate.
- Use *bytes.Buffer for *Tiff String() method.
