### PR TITLE
tiff: Make names more consistent with the spec. Note: API change.

### DIFF
--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -184,16 +184,16 @@ func (t *Tag) convertVals() {
 			t.ratVals[i] = []int64{int64(n), int64(d)}
 		}
 	case 11: // float32
+		t.floatVals = make([]float64, int(t.Ncomp))
 		for i := 0; i < int(t.Ncomp); i++ {
-			t.floatVals = make([]float64, int(t.Ncomp))
 			var v float32
 			err := binary.Read(r, t.order, &v)
 			panicOn(err)
 			t.floatVals[i] = float64(v)
 		}
 	case 12: // float64 (double)
+		t.floatVals = make([]float64, int(t.Ncomp))
 		for i := 0; i < int(t.Ncomp); i++ {
-			t.floatVals = make([]float64, int(t.Ncomp))
 			var u float64
 			err := binary.Read(r, t.order, &u)
 			panicOn(err)

--- a/tiff/tiff.go
+++ b/tiff/tiff.go
@@ -1,4 +1,5 @@
-// Package tiff implements TIFF decoding as defined in TIFF 6.0 specification.
+// Package tiff implements TIFF decoding as defined in TIFF 6.0 specification at
+// http://partners.adobe.com/public/developer/en/tiff/TIFF6.pdf
 package tiff
 
 import (
@@ -55,7 +56,7 @@ func Decode(r io.Reader) (*Tiff, error) {
 	// check for special tiff marker
 	var sp int16
 	err = binary.Read(buf, t.Order, &sp)
-	if err != nil || 0x002A != sp {
+	if err != nil || 42 != sp {
 		return nil, errors.New("tiff: could not find special tiff marker")
 	}
 

--- a/tiff/tiff_test.go
+++ b/tiff/tiff_test.go
@@ -17,10 +17,10 @@ type input struct {
 }
 
 type output struct {
-	id     uint16
-	format uint16
-	count  uint32
-	val    []byte
+	id    uint16
+	typ   uint16
+	count uint32
+	val   []byte
 }
 
 type tagTest struct {
@@ -151,11 +151,11 @@ func testSingle(t *testing.T, order binary.ByteOrder, in input, out output, i in
 	if tg.Id != out.id {
 		t.Errorf("(%v) tag %v id decode: expected %v, got %v", order, i, out.id, tg.Id)
 	}
-	if tg.Fmt != out.format {
-		t.Errorf("(%v) tag %v format decode: expected %v, got %v", order, i, out.format, tg.Fmt)
+	if tg.Type != out.typ {
+		t.Errorf("(%v) tag %v type decode: expected %v, got %v", order, i, out.typ, tg.Type)
 	}
-	if tg.Ncomp != out.count {
-		t.Errorf("(%v) tag %v N-components decode: expected %v, got %v", order, i, out.count, tg.Ncomp)
+	if tg.Count != out.count {
+		t.Errorf("(%v) tag %v component count decode: expected %v, got %v", order, i, out.count, tg.Count)
 	}
 	if !bytes.Equal(tg.Val, out.val) {
 		t.Errorf("(%v) tag %v value decode: expected %v, got %v", order, i, out.val, tg.Val)


### PR DESCRIPTION
Field names are derived from Section 2, Image File Directory (TIFF spec 6.0)
    Tag: "Id" seems appropriate even though it deviates from the spec, since
         name "Tag" is used to represent the struct.
    Type: Rename "Fmt" to "Type" to make this field consistent with the spec
    Count: Rename "Ncomp" to "Count" to make this field consistent with the
           The "output" struct in "tiff_test.go" already uses the name "coun
    Value/Offset: "Val" is consistent with the spec.

This pull request depends on/includes pull request 8 which fixes a bug in convertVals.
