### PR TITLE
fix shadowed err bug

### DIFF
--- a/exif/exif.go
+++ b/exif/exif.go
@@ -144,7 +144,8 @@ func Decode(r io.Reader) (*Exif, error) {
 		er = bytes.NewReader(b.Bytes())
 	} else {
 		// Locate the JPEG APP1 header.
-		sec, err := newAppSec(jpeg_APP1, r)
+		var sec *appSec
+		sec, err = newAppSec(jpeg_APP1, r)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hey there,

here's a fix for a bug that I think we introduced when Bill added TIFF images support, sorry about that.
Without the fix, the err from the outer scope is shadowed by the err declared by newAppSec. So when tiff.Decode fails, the outer scope check for the error does not see that failure, and panic ensues :-)

Mathieu
