### PR TITLE
Mknote example addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ func main() {
 	}
 
 	x, err := exif.Decode(f)
+	// Register Camera make specific parses, currently Nikon and Canon.
 	for _, parser := range mknote.All {
 		x.RegisterParsers(parser)
 	}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ import (
   "fmt"
 
   "github.com/rwcarlsen/goexif/exif"
+  "github.com/rwcarlsen/goexif/mknote"
 )
 
 func main() {
@@ -42,6 +43,9 @@ func main() {
 	}
 
 	x, err := exif.Decode(f)
+	for _, parser := range mknote.All {
+		x.RegisterParsers(parser)
+	}
 	defer f.Close()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
I think it's easy to miss that goexif supports Canon and Nikon specifc tags so I suggest this addition to the example Decode.
