### PR TITLE
Adds explicit error value for short tag read and helper to identify error.

### DIFF
--- a/exif/exif.go
+++ b/exif/exif.go
@@ -27,6 +27,24 @@ const (
 	interopPointer = 0xA005
 )
 
+// A decodeError is returned when the image cannot be decoded as a tiff image.
+type decodeError struct {
+	cause error
+}
+
+func (de decodeError) Error() string {
+	return fmt.Sprintf("exif: decode failed (%v) ", de.cause.Error())
+}
+
+// IsShortReadTagValueError identifies a ErrShortReadTagValue error.
+func IsShortReadTagValueError(err error) bool {
+	de, ok := err.(decodeError)
+	if ok {
+		return de.cause == tiff.ErrShortReadTagValue
+	}
+	return false
+}
+
 // A TagNotPresentError is returned when the requested field is not
 // present in the EXIF.
 type TagNotPresentError FieldName
@@ -249,13 +267,13 @@ func Decode(r io.Reader) (*Exif, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("exif: decode failed (%v) ", err)
+		return nil, decodeError{cause: err}
 	}
 
 	er.Seek(0, 0)
 	raw, err := ioutil.ReadAll(er)
 	if err != nil {
-		return nil, fmt.Errorf("exif: decode failed (%v) ", err)
+		return nil, decodeError{cause: err}
 	}
 
 	// build an exif structure from the tiff

--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -25,6 +25,8 @@ const (
 	OtherVal
 )
 
+var ErrShortReadTagValue = errors.New("tiff: short read of tag value")
+
 var formatNames = map[Format]string{
 	IntVal:    "int",
 	FloatVal:  "float",
@@ -152,7 +154,7 @@ func DecodeTag(r ReadAtReader, order binary.ByteOrder) (*Tag, error) {
 		if err != nil {
 			return t, errors.New("tiff: tag value read failed: " + err.Error())
 		} else if n != int64(valLen) {
-			return t, errors.New("tiff: short read of tag value")
+			return t, ErrShortReadTagValue
 		}
 		t.Val = buff.Bytes()
 


### PR DESCRIPTION
This change is based on a use case from the [camlistore](https://camlistore.org/) project. There we first optimistically pass only a prefix of an image to the decoder hoping that the prefix is sufficient to get metadata out, but would like to pass the entire file in case the decoding fails because the prefix is not sufficient.

The below changes add an error value and helper to identify it that can be used in other projects (like camlistore) to identify a short read without having to match on the error message.

Please let me know what you think :)
