### PR TITLE
newAppSec: be safer against bogus data length

### DIFF
--- a/exif/exif.go
+++ b/exif/exif.go
@@ -555,11 +555,15 @@ func newAppSec(marker byte, r io.Reader) (*appSec, error) {
 			continue
 		}
 
-		dataLenBytes, err := br.Peek(2)
-		if err != nil {
-			return nil, err
+		dataLenBytes := make([]byte, 2)
+		for k,_ := range dataLenBytes {
+			c, err := br.ReadByte()
+			if err != nil {
+				return nil, err
+			}
+			dataLenBytes[k] = c
 		}
-		dataLen = int(binary.BigEndian.Uint16(dataLenBytes))
+		dataLen = int(binary.BigEndian.Uint16(dataLenBytes)) - 2
 	}
 
 	// read section data
@@ -573,7 +577,6 @@ func newAppSec(marker byte, r io.Reader) (*appSec, error) {
 		}
 		app.data = append(app.data, s[:n]...)
 	}
-	app.data = app.data[2:] // exclude dataLenBytes
 	return app, nil
 }
 


### PR DESCRIPTION
It can apparently happen (with at least one gimp .xcf file), that it has
all the same markers as in a jpeg, up until reading the 2 bytes that would
code for the data length.
Since the data length is supposed to include those 2 bytes, the code was
assuming that the value of data length would be always at least 3, and
slicing under that assumption. Which breaks when e.g. an .xcf file
encodes the value 1 on these 2 bytes.

Fixes #34
