### PR TITLE
Err if rational has a 0-valued denominator

### DIFF
--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -326,6 +326,9 @@ func (t *Tag) Rat(i int) (*big.Rat, error) {
 	if err != nil {
 		return nil, err
 	}
+	if d == 0 {
+		return nil, errors.New("rational has zero-valued denominator")
+	}
 	return big.NewRat(n, d), nil
 }
 

--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -319,8 +319,8 @@ func (t *Tag) typeErr(to Format) error {
 }
 
 // Rat returns the tag's i'th value as a rational number. It returns a nil and
-// an error if this tag's Format is not RatVal.  It panics for zero deminators
-// or if i is out of range.
+// an error if this tag's Format is not RatVal or has a zero denominator.  It 
+// panics i is out of range.
 func (t *Tag) Rat(i int) (*big.Rat, error) {
 	n, d, err := t.Rat2(i)
 	if err != nil {


### PR DESCRIPTION
Encountering panics when ExposureTime values have a denominator of 0 in the RatVal. This change adds a sanity check to ensure that we error appropriately.
