### PR TITLE
Add Address field to Tag struct, and Countable interface to ReadAtRea…

### DIFF
--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -101,6 +101,9 @@ type Tag struct {
 	// field.
 	ValOffset uint32
 
+	// Address hold byte offset of this tag header from the begining of the file.
+	Address uint64
+
 	order     binary.ByteOrder
 	intVals   []int64
 	floatVals []float64
@@ -116,6 +119,7 @@ type Tag struct {
 func DecodeTag(r ReadAtReader, order binary.ByteOrder) (*Tag, error) {
 	t := new(Tag)
 	t.order = order
+	t.Address = uint64(t.Size()) - uint64(t.Len())
 
 	err := binary.Read(r, order, &t.Id)
 	if err != nil {

--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -119,7 +119,7 @@ type Tag struct {
 func DecodeTag(r ReadAtReader, order binary.ByteOrder) (*Tag, error) {
 	t := new(Tag)
 	t.order = order
-	t.Address = uint64(t.Size()) - uint64(t.Len())
+	t.Address = uint64(r.Size()) - uint64(r.Len())
 
 	err := binary.Read(r, order, &t.Id)
 	if err != nil {

--- a/tiff/tiff.go
+++ b/tiff/tiff.go
@@ -11,10 +11,17 @@ import (
 	"io/ioutil"
 )
 
+// Countable is used when count offset from the begining of bytes.
+type Countable interface{
+	Len() int
+	Size() int64
+}
+
 // ReadAtReader is used when decoding Tiff tags and directories
 type ReadAtReader interface {
 	io.Reader
 	io.ReaderAt
+	Countable
 }
 
 // Tiff provides access to a decoded tiff data structure.


### PR DESCRIPTION
Tag struct has value offset, but doesn't have a offset from the beginning of file to self.
Detecting the value address, we can't get  if tag struct doesn't have a value offset, included it.
So my PR is that tag struct have Address field, and calc it.
