### PR TITLE
add source at the root folder to make CI works

### DIFF
--- a/goexif.go
+++ b/goexif.go
@@ -1,0 +1,1 @@
+package goexif


### PR DESCRIPTION
As there is no go source at the root folder, integration scripts using 

```
go list -f '{{range .Imports}}{{.}} {{end}}' ./... | xargs go get -v
go list -f '{{range .TestImports}}{{.}} {{end}}' ./... | xargs go get -v
```

cannot work properly as `go get` expect one golang file. See https://github.com/rande/gonode/blob/master/Makefile and the related travis-ci fealure for reference: https://travis-ci.org/rande/gonode/jobs/109252027
