### PR TITLE
Fixes a panic that can be caused by bad input data

### DIFF
--- a/exif/exif.go
+++ b/exif/exif.go
@@ -144,6 +144,9 @@ var stagePrefix = map[tiffError]string{
 // in x. If parsing a sub-IFD fails, the error is recorded and
 // parsing continues with the remaining sub-IFDs.
 func (p *parser) Parse(x *Exif) error {
+	if len(x.Tiff.Dirs) == 0 {
+		return errors.New("Invalid exif data")
+	}
 	x.LoadTags(x.Tiff.Dirs[0], exifFields, false)
 
 	// thumbnails


### PR DESCRIPTION
Found this panic using go-fuzz.

Relevant panic output was:

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/rwcarlsen/goexif/exif.(*parser).Parse(0xb0c2b0, 0xc4200161b0, 0xc4200161e0, 0x0)
github.com/rwcarlsen/goexif/exif/exif.go:147 +0x4c5
github.com/rwcarlsen/goexif/exif.Decode(0xac2ba0, 0xc420016090, 0xc42054fab8, 0x1051e, 0xc420016090)
github.com/rwcarlsen/goexif/exif/exif.go:287 +0x6ea
[...]
```

I can provide the input that triggered the crash if required.
