### PR TITLE
tiff: ignore all trailing NULLs in case of misleading Count

### DIFF
--- a/tiff/tag.go
+++ b/tiff/tag.go
@@ -179,8 +179,15 @@ func (t *Tag) convertVals() error {
 
 	switch t.Type {
 	case DTAscii:
-		if len(t.Val) > 0 {
-			t.strVal = string(t.Val[:len(t.Val)-1]) // ignore the last byte (NULL).
+		if len(t.Val) <= 0 {
+			break
+		}
+		nullPos := bytes.IndexByte(t.Val, 0)
+		if nullPos == -1 {
+			t.strVal = string(t.Val)
+		} else {
+			// ignore all trailing NULL bytes, in case of a broken t.Count
+			t.strVal = string(t.Val[:nullPos])
 		}
 	case DTByte:
 		var v uint8


### PR DESCRIPTION
As it can apparently happen with some camera software
(https://user-images.githubusercontent.com/2621/39392188-71a66fc4-4a66-11e8-9e3b-694163efa643.jpg),
sometimes a tag bytes will not only have a bunch of trailing NULLs, but
the Count for the data in that tag will be wrongly set too. i.e. instead
of being set to the actual number of relevant bytes to read, it will
be set to the full number of bytes, trailing zeroes included.

As a consequence, the Tag.strVal returned would include these trailing
NULLs too, which would lead to bugs such as
https://github.com/perkeep/perkeep/issues/1127

This change therefore makes sure to remove all trailing NULLs from the
data, in the case of DTAscii at least.