### PR TITLE
Add support for Apple iOS maker notes

### DIFF
--- a/mknote/fields.go
+++ b/mknote/fields.go
@@ -135,6 +135,14 @@ const (
 	Canon_0x00b5         exif.FieldName = "Canon.0x00b5"
 	Canon_0x00c0         exif.FieldName = "Canon.0x00c0"
 	Canon_0x00c1         exif.FieldName = "Canon.0x00c1"
+
+	// Apple-specific fields
+	Apple_RunTime            exif.FieldName = "Apple.RunTime"
+	Apple_AccelerationVector exif.FieldName = "Apple.AccelerationVector"
+	Apple_HDRImageType       exif.FieldName = "Apple.HDRImageType"
+	Apple_BurstUUID          exif.FieldName = "Apple.BurstUUID"
+	Apple_ContentIdentifier  exif.FieldName = "Apple.ContentIdentifier"
+	Apple_ImageUniqueID      exif.FieldName = "Apple.ImageUniqueID"
 )
 
 var makerNoteCanonFields = map[uint16]exif.FieldName{
@@ -267,4 +275,14 @@ var makerNoteNikon3Fields = map[uint16]exif.FieldName{
 	0x0e10: ScanIFD,
 	0x0e1d: ICCProfile,
 	0x0e1e: CaptureOutput,
+}
+
+// Source: https://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Apple.html
+var makerNoteAppleFields = map[uint16]exif.FieldName{
+	0x0003: Apple_RunTime, // undefined type but it is a binary serialized CMTime structure
+	0x0008: Apple_AccelerationVector,
+	0x000a: Apple_HDRImageType,
+	0x000b: Apple_BurstUUID,
+	0x0011: Apple_ContentIdentifier,
+	0x0015: Apple_ImageUniqueID,
 }


### PR DESCRIPTION
Add a parser for makernotes written by Apple iOS devices.  I originally added this to extract the burst UUID values that iOS devices write to collect burst images together. 

Note: Until this PR lands you can use [this code](https://github.com/mostlygeek/goexif-apple-makernotes) to add apple makernote parsing right now. 