### PR TITLE
Add Windows-specific EXIF tags

### DIFF
--- a/exif/fields.go
+++ b/exif/fields.go
@@ -89,7 +89,15 @@ const (
 	SubjectDistanceRange       FieldName = "SubjectDistanceRange"
 	LensMake                   FieldName = "LensMake"
 	LensModel                  FieldName = "LensModel"
-	XPComment                  FieldName = "XPComment"
+)
+
+// Windows-specific tags
+const (
+	XPTitle    FieldName = "XPTitle"
+	XPComment  FieldName = "XPComment"
+	XPAuthor   FieldName = "XPAuthor"
+	XPKeywords FieldName = "XPKeywords"
+	XPSubject  FieldName = "XPSubject"
 )
 
 // thumbnail fields
@@ -166,7 +174,13 @@ var exifFields = map[uint16]FieldName{
 	0x0131: Software,
 	0x013B: Artist,
 	0x8298: Copyright,
+
+	// Windows-specific tags
+	0x9c9b: XPTitle,
 	0x9c9c: XPComment,
+	0x9c9d: XPAuthor,
+	0x9c9e: XPKeywords,
+	0x9c9f: XPSubject,
 
 	// private tags
 	exifPointer: ExifIFDPointer,

--- a/exif/fields.go
+++ b/exif/fields.go
@@ -89,6 +89,7 @@ const (
 	SubjectDistanceRange       FieldName = "SubjectDistanceRange"
 	LensMake                   FieldName = "LensMake"
 	LensModel                  FieldName = "LensModel"
+	XPComment                  FieldName = "XPComment"
 )
 
 // thumbnail fields
@@ -165,6 +166,7 @@ var exifFields = map[uint16]FieldName{
 	0x0131: Software,
 	0x013B: Artist,
 	0x8298: Copyright,
+	0x9c9c: XPComment,
 
 	// private tags
 	exifPointer: ExifIFDPointer,


### PR DESCRIPTION
Adds the tags XPTitle, XPComment, XPAuthor, XPKeywords and XPSubject.

I needed to retrieve data from the XPComment field for a work-related task and found goexif to have a much more pleasant API than all alternatives I've found, so I decided to add these fields.