### PR TITLE
exif: better error messages in two places

### DIFF
--- a/exif/exif.go
+++ b/exif/exif.go
@@ -238,12 +238,12 @@ func Decode(r io.Reader) (*Exif, error) {
 		var sec *appSec
 		sec, err = newAppSec(jpeg_APP1, r)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("exif: could not locate APP1 header: %w", err)
 		}
 		// Strip away EXIF header.
 		er, err = sec.exifReader()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("exif: error stripping EXIF header: %w", err)
 		}
 		tif, err = tiff.Decode(er)
 	}


### PR DESCRIPTION
I'm currently getting "EOF" when I try to read EXIF data from a JPEG
image, and adding better error messages will make it more clear where
that is coming from.